### PR TITLE
fix(performance): use ticker symbols instead of display names

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -2,7 +2,7 @@
 name = "portfolio_rs"
 description = "A command line tool for managing financial investment portfolios written in Rust."
 readme = "README.md"
-version = "0.1.12"
+version = "0.2.0"
 edition = "2021"
 license = "MIT" 
 

--- a/src/portfolio.rs
+++ b/src/portfolio.rs
@@ -80,10 +80,7 @@ impl Portfolio {
         }
 
         if !errors.is_empty() {
-            eprintln!("Warning: Some positions could not be processed:");
-            for error in &errors {
-                eprintln!("  - {}", error);
-            }
+            return Err(errors.join("; "));
         }
 
         Ok(sum)

--- a/src/position.rs
+++ b/src/position.rs
@@ -45,6 +45,10 @@ impl PortfolioPosition {
     pub fn get_amount(&self) -> f64 {
         self.amount
     }
+
+    pub fn get_ticker(&self) -> Option<&str> {
+        self.ticker.as_deref()
+    }
 }
 
 pub fn from_string(data: &str) -> Vec<PortfolioPosition> {


### PR DESCRIPTION
fixes errors in the `performance` subcommand