### PR TITLE
Improve portfolio historic value handling and stabilize tests

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,7 +19,7 @@ tokio = { version = "1.47.1", features = ["full"] }
 yahoo_finance_api = "4.0.0"
 piechart = "1.0.0"
 time = "0.3.41"
-chrono = "0.4.41"
+chrono = { version = "0.4.41", features = ["serde"] }
 sled = "0.34.7"
 colored = "3.0.0"
 confy = { version = "1.0.0", features = ["yaml_conf"], default-features = false }


### PR DESCRIPTION
This PR addresses multiple issues in the Portfolio module related to historic 
value calculation, performance metrics, and unit tests.

closes: #6

### Changes made:

1. **Performance calculation fixes**
   - Fixed `get_performance_data` and `print_performance`:
     - Resolved if/else type mismatch by removing trailing semicolons.
     - Ensured `get_historic_total_value` receives the required `&Db` argument.
     - Safely handled zero-values to prevent division errors.
   
2. **HistoricalPosition handling**
   - Removed unnecessary `.clone()` on references.
   - Suggested adding `#[derive(Clone)]` if cloning is needed in the future.

3. **Tests stabilization**
   - Created `get_historic_total_value_mock` for predictable results.
   - `test_get_historic_total_value` now uses the mock instead of relying 
     on Yahoo Finance API.
   - Ensures stable, repeatable test results even if external APIs fail or 
     tickers are delisted.
   - Historical positions inserted into `sled` test DB for accurate test 
     coverage.
